### PR TITLE
Search Result Mobile Responsive Fix

### DIFF
--- a/src/components/Search/SearchResult.css
+++ b/src/components/Search/SearchResult.css
@@ -16,6 +16,7 @@
     width: 350px;
     border-radius: 10px;
     overflow: hidden;
+    object-fit: cover;
 }
 
 .search-result-info {


### PR DESCRIPTION
On the Search Result page mobile version images not good properly I try to fix them using the object-fit property. Now, this is looking good. :)